### PR TITLE
feat: Implement customizable dashboard widgets for analytics (#12)

### DIFF
--- a/project/src/components/WidgetSettingsModal.tsx
+++ b/project/src/components/WidgetSettingsModal.tsx
@@ -1,0 +1,66 @@
+// src/components/WidgetSettingsModal.tsx
+
+import React from 'react';
+
+// Define props for the modal
+interface WidgetSettingsModalProps {
+  isOpen: boolean; // Controls modal visibility
+  onClose: () => void; // Function to close the modal
+  // This array will hold IDs of currently enabled widgets
+  enabledWidgets: string[]; 
+  // Function to update the enabled widgets list
+  onToggleWidget: (widgetId: string, isEnabled: boolean) => void;
+}
+
+// List of all available widgets with their friendly names and IDs
+const availableWidgets = [
+  { id: 'currentStreak', name: 'Current Streak' },
+  { id: 'dailyCompletion', name: 'Daily Completion Rate' },
+  { id: 'totalCompleted', name: 'Total Habits Completed' },
+  // Add more widgets here as you create them
+];
+
+const WidgetSettingsModal: React.FC<WidgetSettingsModalProps> = ({
+  isOpen,
+  onClose,
+  enabledWidgets,
+  onToggleWidget,
+}) => {
+  if (!isOpen) return null; // Don't render if not open
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl max-w-sm w-full mx-4">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Manage Dashboard Widgets</h2>
+        
+        <div className="space-y-3 mb-6">
+          {availableWidgets.map((widget) => (
+            <div key={widget.id} className="flex items-center">
+              <input
+                type="checkbox"
+                id={widget.id}
+                checked={enabledWidgets.includes(widget.id)}
+                onChange={(e) => onToggleWidget(widget.id, e.target.checked)}
+                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded dark:bg-gray-700 dark:border-gray-600 dark:checked:bg-blue-600 dark:focus:ring-blue-600"
+              />
+              <label htmlFor={widget.id} className="ml-3 text-gray-700 dark:text-gray-300">
+                {widget.name}
+              </label>
+            </div>
+          ))}
+        </div>
+        
+        <div className="flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WidgetSettingsModal;

--- a/project/src/components/widgets/CurrentStreakWidget.tsx
+++ b/project/src/components/widgets/CurrentStreakWidget.tsx
@@ -1,0 +1,23 @@
+// src/components/widgets/CurrentStreakWidget.tsx
+
+import React from 'react';
+
+interface CurrentStreakWidgetProps {
+  longestStreak: number;
+}
+
+const CurrentStreakWidget: React.FC<CurrentStreakWidgetProps> = ({ longestStreak }) => {
+  // Removed inline 'widgetStyle', 'streakValueStyle', 'streakLabelStyle' objects
+  return (
+    // Replaced inline style with Tailwind CSS classes
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 text-center shadow-md 
+                flex flex-col justify-center items-center min-h-[150px]"> {/* min-h-[150px] is Tailwind for min-height */}
+      <div className="text-5xl font-bold text-red-500 mb-1"> {/* Adjusted color to a red that might fit HabitHeat */}
+        {longestStreak}
+      </div>
+      <div className="text-base text-gray-600 dark:text-gray-300">Days Current Streak 🔥</div>
+    </div>
+  );
+};
+
+export default CurrentStreakWidget;

--- a/project/src/components/widgets/DailyCompletionRateWidget.tsx
+++ b/project/src/components/widgets/DailyCompletionRateWidget.tsx
@@ -1,0 +1,33 @@
+// src/components/widgets/DailyCompletionRateWidget.tsx
+
+import React from 'react';
+
+// Define the props interface for the component
+interface DailyCompletionRateWidgetProps {
+  completedHabitsToday: number;
+  totalHabitsToday: number;
+}
+
+const DailyCompletionRateWidget: React.FC<DailyCompletionRateWidgetProps> = ({ completedHabitsToday, totalHabitsToday }) => {
+  const completionPercentage = totalHabitsToday > 0 
+    ? Math.round((completedHabitsToday / totalHabitsToday) * 100) 
+    : 0; // Handle division by zero
+
+  return (
+    // Replaced inline style with Tailwind CSS classes
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 text-center shadow-md 
+                flex flex-col justify-center items-center min-h-[150px]">
+      <div className="text-5xl font-bold text-green-500 mb-1"> {/* Adjusted color to a green */}
+        {completionPercentage}%
+      </div>
+      <div className="text-base text-gray-600 dark:text-gray-300">Daily Habits Completed</div>
+      {totalHabitsToday > 0 && (
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          ({completedHabitsToday} of {totalHabitsToday})
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DailyCompletionRateWidget;

--- a/project/src/components/widgets/TotalHabitsCompletedWidget.tsx
+++ b/project/src/components/widgets/TotalHabitsCompletedWidget.tsx
@@ -1,0 +1,23 @@
+// src/components/widgets/TotalHabitsCompletedWidget.tsx
+
+import React from 'react';
+
+// Define the props interface
+interface TotalHabitsCompletedWidgetProps {
+  totalCompletedHabits: number;
+}
+
+const TotalHabitsCompletedWidget: React.FC<TotalHabitsCompletedWidgetProps> = ({ totalCompletedHabits }) => {
+  return (
+    // Replaced inline style with Tailwind CSS classes
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 text-center shadow-md 
+                flex flex-col justify-center items-center min-h-[150px]">
+      <div className="text-5xl font-bold text-purple-500 mb-1"> {/* Adjusted color to a purple */}
+        {totalCompletedHabits}
+      </div>
+      <div className="text-base text-gray-600 dark:text-gray-300">Total Habits Completed ✅</div>
+    </div>
+  );
+};
+
+export default TotalHabitsCompletedWidget;


### PR DESCRIPTION
### Problem:

Habit Heat's dashboard analytics aren't customizable. Users need control over which insights they see to truly personalize their experience and optimize motivation.

### Proposed Solution:

Develop frontend features for customizable dashboard widgets. This includes:

* **Widget Library:** Reusable components for various analytics (streaks, completion rates, etc.).
* **Customization UI:** A way for users to select and arrange these widgets on their dashboard.

This is a React/TypeScript frontend task.

Output:
<img width="1847" height="1052" alt="main" src="https://github.com/user-attachments/assets/64e30c02-d8e8-4599-bce6-c88c068f1f96" />

<img width="1847" height="1052" alt="managewidget" src="https://github.com/user-attachments/assets/e049eafb-e537-43e4-9720-51d980737798" />


Closes #12